### PR TITLE
Enhance GitHub Actions workflow to check for new package version before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20' # or your preferred version
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
@@ -25,7 +25,23 @@ jobs:
       - name: Build package
         run: npm run build
 
+      - name: Check if version is new
+        id: check-version
+        run: |
+          LOCAL_VERSION=$(node -p "require('./package.json').version")
+          PUBLISHED_VERSION=$(npm view ratelimitapi version || echo "0.0.0")
+          echo "Local: $LOCAL_VERSION"
+          echo "Published: $PUBLISHED_VERSION"
+          if [ "$LOCAL_VERSION" = "$PUBLISHED_VERSION" ]; then
+            echo "No new version to publish."
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "New version detected."
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish to NPM
+        if: steps.check-version.outputs.should_publish == 'true'
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/ratelimitapi.svg)](https://www.npmjs.com/package/ratelimitapi)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![Build status](https://github.com/ratelimitapi/package/actions/workflows/publish.yml/badge.svg)
 
 **This package is currently in early development and not ready for production use.**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/ratelimitapi.svg)](https://www.npmjs.com/package/ratelimitapi)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-![Build status](https://github.com/ratelimitapi/package/actions/workflows/publish.yml/badge.svg)
+![GitHub Actions publish workflow status](https://github.com/ratelimitapi/package/actions/workflows/publish.yml/badge.svg)
 
 **This package is currently in early development and not ready for production use.**
 


### PR DESCRIPTION
This pull request introduces a new version check step in the NPM publish workflow and updates the `README.md` file with a build status badge. These changes aim to improve the publishing process and provide better visibility into the package's build status.

### Workflow improvements:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R28-R44): Added a step to check if the local package version is newer than the published version before publishing to NPM. The `Publish to NPM` step now only runs if a new version is detected.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5): Added a build status badge to display the status of the GitHub Actions workflow for publishing the package.