### PR TITLE
Add permissions for id-token in Python publish job in GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,10 +49,11 @@ jobs:
           npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   publish-pypi:
     name: Publish Python Package to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     
     steps:
       - name: Checkout repo
@@ -94,4 +95,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/python/dist/
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish.yml` file to enhance security and streamline the publishing process for Python packages. The most important changes include adding permissions for the `publish-pypi` job and modifying the PyPI publishing configuration.

### Workflow security and configuration updates:

* `publish-pypi` job: Added `id-token: write` permissions to enhance security by enabling OpenID Connect authentication for the job.
* PyPI publishing: Removed the explicit use of the `PYPI_API_TOKEN` secret, likely in favor of using the newly added OpenID Connect authentication.